### PR TITLE
Template update refactoring and foreign key validation

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,12 +1,18 @@
 import { Module } from '@nestjs/common';
-import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
+import { AppController } from './app.controller';
 import { UsersModule } from './users/users.module';
+import { TemplatesModule } from './templates/templates.module';
 import { EducationalProgramsModule } from './educational-programs/educational-programs.module';
 
 @Module({
-  imports: [AuthModule, UsersModule, EducationalProgramsModule],
+  imports: [
+    AuthModule,
+    UsersModule,
+    EducationalProgramsModule,
+    TemplatesModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/models/template/update-template.dto.ts
+++ b/src/models/template/update-template.dto.ts
@@ -1,4 +1,10 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CreateTemplateDto } from './create-template.dto';
 
-export class UpdateTemplateDto extends PartialType(CreateTemplateDto) {}
+export class UpdateTemplateDto extends PartialType(CreateTemplateDto) {
+  state?: string;
+  areaId?: number;
+  period?: string;
+  responsibleId?: number;
+  revisedById?: number;
+}

--- a/src/templates/templates.service.ts
+++ b/src/templates/templates.service.ts
@@ -110,31 +110,45 @@ export class TemplatesService {
   ): Promise<void> {
     const { areaId, responsibleId, revisedById } = dto;
 
-    const area = await this.prisma.area.findUnique({
-      where: {
-        id: areaId,
-      },
-    });
-    if (!area) {
-      throw new NotFoundException(`Area with ID ${areaId} not found`);
+    const validations = [];
+
+    if (areaId !== undefined) {
+      validations.push(
+        this.prisma.area.count({ where: { id: areaId } }).then((count) => {
+          if (count === 0) {
+            throw new NotFoundException(`Area with ID ${areaId} not found`);
+          }
+        }),
+      );
     }
 
-    const responsible = await this.prisma.users.findUnique({
-      where: {
-        nt: responsibleId,
-      },
-    });
-    if (!responsible) {
-      throw new NotFoundException(`User with NT ${responsibleId} not found`);
+    if (responsibleId !== undefined) {
+      validations.push(
+        this.prisma.users
+          .count({ where: { id: responsibleId } })
+          .then((count) => {
+            if (count === 0) {
+              throw new NotFoundException(
+                `User with NT ${responsibleId} not found`,
+              );
+            }
+          }),
+      );
     }
 
-    const revisedBy = await this.prisma.users.findUnique({
-      where: {
-        nt: revisedById,
-      },
-    });
-    if (!revisedBy) {
-      throw new NotFoundException(`User with NT ${revisedById} not found`);
+    if (revisedById !== undefined) {
+      validations.push(
+        this.prisma.users
+          .count({ where: { nt: revisedById } })
+          .then((count) => {
+            if (count === 0) {
+              throw new NotFoundException(
+                `User with NT ${revisedById} not found`,
+              );
+            }
+          }),
+      );
     }
+    await Promise.all(validations);
   }
 }

--- a/src/templates/templates.service.ts
+++ b/src/templates/templates.service.ts
@@ -53,17 +53,18 @@ export class TemplatesService {
    */
   async update(
     id: number,
-    updateTemplate: UpdateTemplateDto,
+    updateTemplateDto: UpdateTemplateDto,
   ): Promise<Template> {
     await this.validateId(id);
-    await this.validateForeignKeys(updateTemplate);
+    await this.validateForeignKeys(updateTemplateDto);
 
-    return await this.prisma.template.update({
+    const updateTemplate = await this.prisma.template.update({
       where: {
         id,
       },
-      data: { ...updateTemplate },
+      data: { ...updateTemplateDto },
     });
+    return updateTemplate;
   }
 
   /**


### PR DESCRIPTION
## Overview
This pull request refactors the update functionality for the `Template` model and improves the validation of foreign key references. 

## Changes
- **DTOs:** Updated `UpdateTemplateDto` to extend `PartialType(CreateTemplateDto)`, allowing for partial updates of template fields.
- **Service Update Method:** Refactored the `update` method in `TemplatesService` to handle updates efficiently.
- **Foreign Key Validation:** Improved the validation process for foreign keys (`areaId`, `responsibleId`, `revisedById`) using `Promise.all` for better performance.

##Details
1. **DTOs
 - `UpdateTemplateDto`: Extends `PartialType(CreateTemplateDto)` to allow updates of template fields but optionally.

2. **TemplatesService**
 - `update()`: Handles the update of a template by ID, using the updated `UpdateTemplateDto` for partial updates.
 - `validateForeignKeys()`: Refactored to use `Promise.all` for efficient validation of foreign keys.

3. **Foreign Key Validation**
 - Validates the existence of `areaId`, `responsibleId`, and `revisedById` only if they are provided in the DTO.
 - Uses `Promise.all` to run validations concurrently, improving performance and code readability.

## Related Issues
- Closes #23 

##Notes
- Ensure that related records (e.g., `Area`, `Users`) exist in the database before testing the `Template` endpoints to avoid foreign key constraint errors.

Thank you for reviewing this pull request. I look forward to your feedback.